### PR TITLE
Jest readability

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,6 @@
   "name": "dom-delegate",
   "description": "Create and manage a DOM event delegator.",
   "main": "lib/delegate.js",
-  "ignore": ["test", "GruntFile.js", ".npmignore", ".gitignore", "README.md", "component.json", "package.json"],
+  "ignore": ["test", "GruntFile.js", ".npmignore", ".gitignore", "README.md", "component.json"],
   "license": "MIT"
 }


### PR DESCRIPTION
Stop bower from ignoring package.json on install; package.json contains the `main` field necessary for `jest` in order to load the package

More details at: https://github.com/Financial-Times/di2-front-end-render/issues/901