### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ script:
 language: node_js
 
 node_js:
-  - "0.10"
+  - "8.9"


### PR DESCRIPTION
The node version for the travis job is seriously out of date and should be bumped to the current LTS, which is v8.9.0, codename "Carbon".